### PR TITLE
test: add comprehensive unit tests for TES and WES converters

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
 
     - name: Lint with Ruff
       run: |
-        poetry run ruff check crategen/
+        poetry run ruff check crategen/ tests/
 
     - name: Type check with Mypy
       run: |
@@ -39,6 +39,6 @@ jobs:
       run: |
         poetry add pytest pytest-cov pytest-mock
 
-    # - name: Run tests
-    #   run: |
-    #     poetry run pytest --cov=crategen
+    - name: Run tests
+      run: |
+        poetry run pytest --cov=crategen

--- a/tests/data/input/tes_example.json
+++ b/tests/data/input/tes_example.json
@@ -1,0 +1,16 @@
+{
+  "id": "task-id-1",
+  "name": "example-task-1",
+  "description": "Example task description 1",
+  "executors": [{"image": "executor-image-1"}],
+  "inputs": [
+      {"url": "input-url-1", "path": "input-path-1"},
+      {"url": "input-url-2", "path": "input-path-2"}
+  ],
+  "outputs": [
+      {"url": "output-url-1", "path": "output-path-1"}
+  ],
+  "creation_time": "2023-07-10T14:30:00Z",
+  "logs": [{"end_time": "2023-07-10T15:30:00Z"}]
+}
+

--- a/tests/data/input/tes_example_with_missing_fields.json
+++ b/tests/data/input/tes_example_with_missing_fields.json
@@ -1,0 +1,10 @@
+{
+    "id": "task-id-3",
+    "name": "example-task-3",
+    "description": "Example task description 3",
+    "executors": [{"image": "executor-image-3"}],
+    "inputs": [],
+    "outputs": [],
+    "creation_time": "2023-07-12T12:00:00Z",
+    "logs": [{"end_time": "2023-07-12T12:30:00Z"}]
+}

--- a/tests/data/input/wes_example.json
+++ b/tests/data/input/wes_example.json
@@ -1,0 +1,12 @@
+{
+  "run_id": "run-id-1",
+  "run_log": {
+      "name": "example-run-1",
+      "start_time": "2023-07-10T14:30:00Z",
+      "end_time": "2023-07-10T15:30:00Z"
+  },
+  "state": "COMPLETED",
+  "outputs": [
+      {"location": "output-location-1", "name": "output-name-1"}
+  ]
+}

--- a/tests/data/output/tes_to_wrroc_output.json
+++ b/tests/data/output/tes_to_wrroc_output.json
@@ -1,0 +1,24 @@
+{
+    "@id": "task-id-1",
+    "name": "example-task-1",
+    "description": "Example task description 1",
+    "instrument": "executor-image-1",
+    "object": [
+        {
+            "@id": "input-url-1",
+            "name": "input-path-1"
+        },
+        {
+            "@id": "input-url-2",
+            "name": "input-path-2"
+        }
+    ],
+    "result": [
+        {
+            "@id": "output-url-1",
+            "name": "output-path-1"
+        }
+    ],
+    "startTime": "2023-07-10T14:30:00Z",
+    "endTime": "2023-07-10T15:30:00Z"
+}

--- a/tests/data/output/tes_to_wrroc_output_with_missing_fields.json
+++ b/tests/data/output/tes_to_wrroc_output_with_missing_fields.json
@@ -1,0 +1,10 @@
+{
+    "@id": "task-id-3",
+    "name": "example-task-3",
+    "description": "Example task description 3",
+    "instrument": "executor-image-3",
+    "object": [],
+    "result": [],
+    "startTime": "2023-07-12T12:00:00Z",
+    "endTime": "2023-07-12T12:30:00Z"
+}

--- a/tests/data/output/wes_to_wrroc_outpu.json
+++ b/tests/data/output/wes_to_wrroc_outpu.json
@@ -1,0 +1,13 @@
+{
+    "@id": "run-id-1",
+    "name": "example-run-1",
+    "status": "COMPLETED",
+    "startTime": "2023-07-10T14:30:00Z",
+    "endTime": "2023-07-10T15:30:00Z",
+    "result": [
+        {
+            "@id": "output-location-1",
+            "name": "output-name-1"
+        }
+    ]
+}

--- a/tests/unit/test_tes_converter.py
+++ b/tests/unit/test_tes_converter.py
@@ -1,0 +1,122 @@
+import unittest
+from crategen.converters.tes_converter import TESConverter
+
+class TestTESConverter(unittest.TestCase):
+
+    def setUp(self):
+        self.converter = TESConverter()
+
+    def test_convert_to_wrroc(self):
+        tes_data = {
+            "id": "task-id-1",
+            "name": "example-task-1",
+            "description": "Example task description 1",
+            "executors": [{"image": "executor-image-1"}],
+            "inputs": [
+                {"url": "input-url-1", "path": "input-path-1"},
+                {"url": "input-url-2", "path": "input-path-2"}
+            ],
+            "outputs": [
+                {"url": "output-url-1", "path": "output-path-1"}
+            ],
+            "creation_time": "2023-07-10T14:30:00Z",
+            "logs": [{"end_time": "2023-07-10T15:30:00Z"}]
+        }
+
+        expected_wrroc_data = {
+            "@id": "task-id-1",
+            "name": "example-task-1",
+            "description": "Example task description 1",
+            "instrument": "executor-image-1",
+            "object": [
+                {"@id": "input-url-1", "name": "input-path-1"},
+                {"@id": "input-url-2", "name": "input-path-2"}
+            ],
+            "result": [
+                {"@id": "output-url-1", "name": "output-path-1"}
+            ],
+            "startTime": "2023-07-10T14:30:00Z",
+            "endTime": "2023-07-10T15:30:00Z"
+        }
+
+        result = self.converter.convert_to_wrroc(tes_data)
+        self.assertEqual(result, expected_wrroc_data)
+
+    def test_convert_from_wrroc(self):
+        wrroc_data = {
+            "@id": "task-id-1",
+            "name": "example-task-1",
+            "description": "Example task description 1",
+            "instrument": "executor-image-1",
+            "object": [
+                {"@id": "input-url-1", "name": "input-path-1"},
+                {"@id": "input-url-2", "name": "input-path-2"}
+            ],
+            "result": [
+                {"@id": "output-url-1", "name": "output-path-1"}
+            ],
+            "startTime": "2023-07-10T14:30:00Z",
+            "endTime": "2023-07-10T15:30:00Z"
+        }
+
+        expected_tes_data = {
+            "id": "task-id-1",
+            "name": "example-task-1",
+            "description": "Example task description 1",
+            "executors": [{"image": "executor-image-1"}],
+            "inputs": [
+                {"url": "input-url-1", "path": "input-path-1"},
+                {"url": "input-url-2", "path": "input-path-2"}
+            ],
+            "outputs": [
+                {"url": "output-url-1", "path": "output-path-1"}
+            ],
+            "creation_time": "2023-07-10T14:30:00Z",
+            "logs": [{"end_time": "2023-07-10T15:30:00Z"}]
+        }
+
+        result = self.converter.convert_from_wrroc(wrroc_data)
+        self.assertEqual(result, expected_tes_data)
+
+    def test_convert_to_wrroc_missing_fields(self):
+        tes_data = {
+            "id": "task-id-2",
+            "name": "example-task-2"
+        }
+
+        expected_wrroc_data = {
+            "@id": "task-id-2",
+            "name": "example-task-2",
+            "description": "",
+            "instrument": None,
+            "object": [],
+            "result": [],
+            "startTime": None,
+            "endTime": None
+        }
+
+        result = self.converter.convert_to_wrroc(tes_data)
+        self.assertEqual(result, expected_wrroc_data)
+
+    def test_convert_from_wrroc_missing_fields(self):
+        wrroc_data = {
+            "@id": "task-id-2",
+            "name": "example-task-2"
+        }
+
+        expected_tes_data = {
+            "id": "task-id-2",
+            "name": "example-task-2",
+            "description": "",
+            "executors": [{"image": ""}],
+            "inputs": [],
+            "outputs": [],
+            "creation_time": "",
+            "logs": [{"end_time": ""}]
+        }
+
+        result = self.converter.convert_from_wrroc(wrroc_data)
+        self.assertEqual(result, expected_tes_data)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/unit/test_wes_converter.py
+++ b/tests/unit/test_wes_converter.py
@@ -1,0 +1,98 @@
+import unittest
+from crategen.converters.wes_converter import WESConverter
+
+class TestWESConverter(unittest.TestCase):
+
+    def setUp(self):
+        self.converter = WESConverter()
+
+    def test_convert_to_wrroc(self):
+        wes_data = {
+            "run_id": "run-id-1",
+            "run_log": {
+                "name": "example-run-1",
+                "start_time": "2023-07-10T14:30:00Z",
+                "end_time": "2023-07-10T15:30:00Z"
+            },
+            "state": "COMPLETED",
+            "outputs": [{"location": "output-location-1", "name": "output-name-1"}]
+        }
+
+        expected_wrroc_data = {
+            "@id": "run-id-1",
+            "name": "example-run-1",
+            "status": "COMPLETED",
+            "startTime": "2023-07-10T14:30:00Z",
+            "endTime": "2023-07-10T15:30:00Z",
+            "result": [{"@id": "output-location-1", "name": "output-name-1"}]
+        }
+
+        result = self.converter.convert_to_wrroc(wes_data)
+        self.assertEqual(result, expected_wrroc_data)
+
+    def test_convert_from_wrroc(self):
+        wrroc_data = {
+            "@id": "run-id-1",
+            "name": "example-run-1",
+            "status": "COMPLETED",
+            "startTime": "2023-07-10T14:30:00Z",
+            "endTime": "2023-07-10T15:30:00Z",
+            "result": [{"@id": "output-location-1", "name": "output-name-1"}]
+        }
+
+        expected_wes_data = {
+            "run_id": "run-id-1",
+            "run_log": {
+                "name": "example-run-1",
+                "start_time": "2023-07-10T14:30:00Z",
+                "end_time": "2023-07-10T15:30:00Z"
+            },
+            "state": "COMPLETED",
+            "outputs": [{"location": "output-location-1", "name": "output-name-1"}]
+        }
+
+        result = self.converter.convert_from_wrroc(wrroc_data)
+        self.assertEqual(result, expected_wes_data)
+
+    def test_convert_to_wrroc_missing_fields(self):
+        wes_data = {
+            "run_id": "run-id-2",
+            "run_log": {
+                "name": "example-run-2"
+            }
+        }
+
+        expected_wrroc_data = {
+            "@id": "run-id-2",
+            "name": "example-run-2",
+            "status": "",
+            "startTime": None,
+            "endTime": None,
+            "result": []
+        }
+
+        result = self.converter.convert_to_wrroc(wes_data)
+        self.assertEqual(result, expected_wrroc_data)
+
+    def test_convert_from_wrroc_missing_fields(self):
+        wrroc_data = {
+            "@id": "run-id-2",
+            "name": "example-run-2"
+        }
+
+        expected_wes_data = {
+            "run_id": "run-id-2",
+            "run_log": {
+                "name": "example-run-2",
+                "start_time": "",
+                "end_time": ""
+            },
+            "state": "",
+            "outputs": []
+        }
+
+        result = self.converter.convert_from_wrroc(wrroc_data)
+        self.assertEqual(result, expected_wes_data)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This PR adds unit tests for the TES and WES converters and includes dummy data for testing purposes. The objective is to ensure that all components are working correctly and to provide a foundation for further testing and validation.


# Details

### Unit Tests for TES Converter

**Tests the conversion from TES to WRROC**

- Tests with complete data
- Tests with missing fields

**Tests the conversion from WRROC to TES**

- Tests with complete data
- Tests with missing fields

### Unit Tests for WES Converter

**Tests the conversion from WES to WRROC**

- Tests with complete data
- Tests with missing fields

**Tests the conversion from WRROC to WES**

- Tests with complete data
- Tests with missing fields

## Instructions for Running the Tests

**1. Install Dependencies:**
Ensure that all dependencies are installed:
```bash
poetry install
```

**2. Run the Unit Tests:**
Execute the following command to run the unit tests:
```bash
poetry run pytest tests/unit
```

## Run the TES to WRROC Conversion

Use the CLI to convert the TES input data to WRROC format.
```bash
poetry run python -m crategen.cli --input tests/data/input/tes_example.json --output tests/data/output/tes_to_wrroc_output.json --conversion-type tes-to-wrroc
```
Verify the output in `tes_to_wrroc_output.json`.

## Run the WES to WRROC Conversion
Use the CLI to convert the WES input data to WRROC format.
```bash
poetry run python -m crategen.cli --input tests/data/input/wes_example.json --output tests/data/output/wes_to_wrroc_output.json --conversion-type wes-to-wrroc
```
Verify the output in `wes_to_wrroc_output.json`.
