### PR TITLE
feat: add WRROC models, validators & unit tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,6 @@ jobs:
       run: |
         poetry add pytest pytest-cov pytest-mock
 
-    # - name: Run tests
-    #   run: |
-    #     poetry run pytest --cov=crategen
+    - name: Run tests
+      run: |
+        poetry run pytest --cov=crategen

--- a/crategen/models.py
+++ b/crategen/models.py
@@ -1,0 +1,279 @@
+from pydantic import BaseModel
+from typing import Optional
+
+
+class Executor(BaseModel):
+    """
+    A model representing an executor in the Task Execution Service (TES).
+
+    Attributes:
+        image (str): The Docker image to be used.
+        command (list[str]): The command to be executed.
+    """
+    image: str
+    command: list[str]
+
+
+class TESInputs(BaseModel):
+    """
+    A model representing input files in TES.
+
+    Attributes:
+        url (str): The URL of the input file.
+        path (str): The path where the input file should be placed.
+    """
+    url: str
+    path: str
+
+
+class TESOutputs(BaseModel):
+    """
+    A model representing output files in TES.
+
+    Attributes:
+        url (str): The URL of the output file.
+        path (str): The path where the output file is stored.
+    """
+    url: str
+    path: str
+
+
+class TESLogs(BaseModel):
+    """
+    A model representing logs in TES.
+
+    Attributes:
+        end_time (Optional[str]): The time the task ended.
+    """
+    end_time: Optional[str] = None
+
+
+class TESData(BaseModel):
+    """
+    A model representing a TES task.
+
+    Attributes:
+        id (str): The unique identifier for the TES task.
+        name (str): The name of the TES task.
+        description (Optional[str]): A brief description of the TES task.
+        executors (list[Executor]): The executors associated with the TES task.
+        inputs (list[TESInputs]): The inputs to the TES task.
+        outputs (list[TESOutputs]): The outputs of the TES task.
+        creation_time (str): The time the task was created.
+        logs (list[TESLogs]): Logs associated with the TES task.
+    """
+    id: str
+    name: str
+    description: Optional[str] = ""
+    executors: list[Executor]
+    inputs: list[TESInputs]
+    outputs: list[TESOutputs]
+    creation_time: str
+    logs: list[TESLogs]
+
+    class Config:
+        extra = "forbid"
+
+
+class WESRunLog(BaseModel):
+    """
+    A model representing a run log in the Workflow Execution Service (WES).
+
+    Attributes:
+        name (Optional[str]): The name of the run.
+        start_time (Optional[str]): The start time of the run.
+        end_time (Optional[str]): The end time of the run.
+        cmd (Optional[list[str]]): The command executed in the run.
+        stdout (Optional[str]): The path to the stdout log.
+        stderr (Optional[str]): The path to the stderr log.
+        exit_code (Optional[int]): The exit code of the run.
+    """
+    name: Optional[str] = None
+    start_time: Optional[str] = None
+    end_time: Optional[str] = None
+    cmd: Optional[list[str]] = None
+    stdout: Optional[str] = None
+    stderr: Optional[str] = None
+    exit_code: Optional[int] = None
+
+
+class WESOutputs(BaseModel):
+    """
+    A model representing output files in WES.
+
+    Attributes:
+        location (str): The URL of the output file.
+        name (str): The name of the output file.
+    """
+    location: str
+    name: str
+
+
+class WESRequest(BaseModel):
+    """
+    A model representing a workflow request in WES.
+
+    Attributes:
+        workflow_params (dict[str, str]): The parameters for the workflow.
+        workflow_type (str): The type of the workflow (e.g., CWL).
+        workflow_type_version (str): The version of the workflow type.
+        tags (Optional[dict[str, str]]): Additional tags associated with the workflow.
+    """
+    workflow_params: dict[str, str]
+    workflow_type: str
+    workflow_type_version: str
+    tags: Optional[dict[str, str]] = None
+
+
+class WESData(BaseModel):
+    """
+    A model representing a WES run.
+
+    Attributes:
+        run_id (str): The unique identifier for the WES run.
+        request (WESRequest): The request associated with the WES run.
+        state (str): The state of the WES run.
+        run_log (WESRunLog): The log of the WES run.
+        task_logs (Optional[list[WESRunLog]]): The logs of individual tasks within the run.
+        outputs (list[WESOutputs]): The outputs of the WES run.
+    """
+    run_id: str
+    request: WESRequest
+    state: str
+    run_log: WESRunLog
+    task_logs: Optional[list[WESRunLog]] = None
+    outputs: list[WESOutputs]
+
+    class Config:
+        extra = "forbid"
+
+
+class WRROCInputs(BaseModel):
+    """
+    A model representing inputs in WRROC.
+
+    Attributes:
+        id (str): The unique identifier for the input.
+        name (str): The name of the input.
+    """
+    id: str
+    name: str
+
+
+class WRROCOutputs(BaseModel):
+    """
+    A model representing outputs in WRROC.
+
+    Attributes:
+        id (str): The unique identifier for the output.
+        name (str): The name of the output.
+    """
+    id: str
+    name: str
+
+
+class WRROCDataBase(BaseModel):
+    """
+    A base model representing common fields for WRROC entities.
+
+    Attributes:
+        id (str): The unique identifier for the WRROC entity.
+        name (str): The name of the WRROC entity.
+        description (Optional[str]): A brief description of the WRROC entity.
+        instrument (Optional[str]): The instrument used in the WRROC entity.
+        object (list[WRROCInputs]): A list of input objects related to the WRROC entity.
+        result (list[WRROCOutputs]): A list of output results related to the WRROC entity.
+        startTime (Optional[str]): The start time of the WRROC entity.
+        endTime (Optional[str]): The end time of the WRROC entity.
+    """
+    id: str
+    name: str
+    description: Optional[str] = ""
+    instrument: Optional[str] = None
+    object: list[WRROCInputs]
+    result: list[WRROCOutputs]
+    startTime: Optional[str] = None
+    endTime: Optional[str] = None
+
+    class Config:
+        extra = "forbid"
+
+
+class WRROCData(WRROCDataBase):
+    """
+    A model representing a WRROC entity, inheriting from WRROCDataBase.
+    """
+    pass
+
+
+class WRROCDataTES(WRROCDataBase):
+    """
+    A model representing WRROC data specifically for TES conversion.
+    
+    This model inherits from WRROCDataBase and includes all the necessary fields required for TES conversion.
+    """
+    pass
+
+
+class WRROCDataWES(WRROCDataBase):
+    """
+    A model representing WRROC data specifically for WES conversion.
+
+    This model inherits from WRROCDataBase and includes additional fields required for WES conversion.
+    """
+    status: str
+
+
+class WRROCProcess(BaseModel):
+    """
+    A model representing the WRROC Process Run profile.
+
+    Attributes:
+        id (str): The unique identifier for the WRROC entity.
+        name (str): The name of the WRROC entity.
+        description (Optional[str]): A brief description of the WRROC entity.
+        startTime (Optional[str]): The start time of the process.
+        endTime (Optional[str]): The end time of the process.
+        object (Optional[list[dict[str, str]]]): A list of input objects related to the process.
+    """
+    id: str
+    name: str
+    description: Optional[str] = ""
+    startTime: Optional[str] = None
+    endTime: Optional[str] = None
+    object: Optional[list[dict[str, str]]] = None
+
+    class Config:
+        extra = "forbid"
+
+
+class WRROCWorkflow(WRROCProcess):
+    """
+    A model representing the WRROC Workflow Run profile, inheriting from WRROCProcess.
+
+    Attributes:
+        workflowType (Optional[str]): The type of the workflow.
+        workflowVersion (Optional[str]): The version of the workflow.
+        result (Optional[list[dict[str, str]]]): A list of output results related to the workflow.
+    """
+    workflowType: Optional[str] = None
+    workflowVersion: Optional[str] = None
+    result: Optional[list[dict[str, str]]] = None
+
+    class Config:
+        extra = "forbid"
+
+
+class WRROCProvenance(WRROCWorkflow):
+    """
+    A model representing the WRROC Provenance Run profile, inheriting from WRROCWorkflow.
+
+    Attributes:
+        provenanceData (Optional[str]): Data related to the provenance of the workflow.
+        agents (Optional[list[dict[str, str]]]): A list of agents involved in the workflow.
+    """
+    provenanceData: Optional[str] = None
+    agents: Optional[list[dict[str, str]]] = None
+
+    class Config:
+        extra = "forbid"

--- a/crategen/validators.py
+++ b/crategen/validators.py
@@ -1,0 +1,109 @@
+from pydantic import ValidationError
+from typing import Union
+from .models import WRROCProcess, WRROCWorkflow, WRROCProvenance
+from urllib.parse import urlparse
+
+def validate_wrroc(data: dict) -> Union[WRROCProvenance, WRROCWorkflow, WRROCProcess]:
+    """
+    Validate that the input data is a valid WRROC entity and determine which profile it adheres to.
+    
+    This function attempts to validate the input data against the WRROCProvenance model first.
+    If that validation fails, it attempts validation against the WRROCWorkflow model.
+    If that also fails, it finally attempts validation against the WRROCProcess model.
+    
+    Args:
+        data (dict): The input data to validate.
+    
+    Returns:
+        Union[WRROCProvenance, WRROCWorkflow, WRROCProcess]: The validated WRROC data, indicating the highest profile the data adheres to.
+    
+    Raises:
+        ValueError: If the data does not adhere to any of the WRROC profiles.
+    """
+    # Convert '@id' to 'id' for validation purposes
+    if '@id' in data:
+        data['id'] = data.pop('@id')
+
+    errors = []
+
+    try:
+        return WRROCProvenance(**data)
+    except ValidationError as e:
+        errors.extend(e.errors())
+
+    try:
+        return WRROCWorkflow(**data)
+    except ValidationError as e:
+        errors.extend(e.errors())
+
+    try:
+        return WRROCProcess(**data)
+    except ValidationError as e:
+        errors.extend(e.errors())
+        raise ValueError(f"Invalid WRROC data: {errors}")
+
+def validate_wrroc_tes(data: dict) -> WRROCProcess:
+    """
+    Validate that the input data contains the fields required for WRROC to TES conversion.
+
+    This function first validates that the data is a valid WRROC entity by calling `validate_wrroc`.
+    Then it checks that the data contains all necessary fields for TES conversion.
+
+    Args:
+        data (dict): The input data to validate.
+
+    Returns:
+        WRROCProcess: The validated WRROC data that is suitable for TES conversion.
+
+    Raises:
+        ValueError: If the data is not valid WRROC data or does not contain the necessary fields for TES conversion.
+    """
+    validated_data = validate_wrroc(data)
+    required_fields = ["id", "name", "object", "result"]
+
+    missing_fields = [field for field in required_fields if getattr(validated_data, field) is None]
+
+    if missing_fields:
+        raise ValueError(f"Missing required field(s) for TES conversion: {', '.join(missing_fields)}")
+
+    return validated_data
+
+def validate_wrroc_wes(data: dict) -> WRROCWorkflow:
+    """
+    Validate that the input data contains the fields required for WRROC to WES conversion.
+
+    This function first validates that the data is a valid WRROCWorkflow entity by calling `validate_wrroc`.
+    Then it checks that the data contains all necessary fields for WES conversion.
+
+    Args:
+        data (dict): The input data to validate.
+
+    Returns:
+        WRROCWorkflow: The validated WRROC data that is suitable for WES conversion.
+
+    Raises:
+        ValueError: If the data is not valid WRROC data or does not contain the necessary fields for WES conversion.
+    """
+    validated_data = validate_wrroc(data)
+
+    if not isinstance(validated_data, WRROCWorkflow):
+        raise ValueError("The validated data is not a WRROCWorkflow entity.")
+
+    required_fields = ["id", "name", "workflowType", "workflowVersion", "result"]
+
+    missing_fields = [field for field in required_fields if getattr(validated_data, field) is None]
+
+    if missing_fields:
+        raise ValueError(f"Missing required field(s) for WES conversion: {', '.join(missing_fields)}")
+
+    # Validate URLs in the result field, only if result is not None
+    if validated_data.result is not None:
+        for result in validated_data.result:
+            url = result['id']
+            parsed_url = urlparse(url)
+            if not all([parsed_url.scheme, parsed_url.netloc]):
+                raise ValueError(f"Invalid URL in result: {url}")
+
+    return validated_data
+
+

--- a/tests/unit/test_wrroc_models.py
+++ b/tests/unit/test_wrroc_models.py
@@ -1,0 +1,235 @@
+import unittest
+from pydantic import ValidationError
+
+from crategen.models import WRROCProcess, WRROCWorkflow, WRROCProvenance
+from crategen.validators import validate_wrroc, validate_wrroc_tes, validate_wrroc_wes
+
+class TestWRROCModels(unittest.TestCase):
+    """
+    Unit tests for the WRROC models to ensure they work as expected.
+    """
+
+    def test_wrroc_process_model(self):
+        """
+        Test that the WRROCProcess model correctly validates data.
+        """
+        data = {
+            "id": "process-id",
+            "name": "Test Process",
+            "description": "A simple process",
+            "startTime": "2024-07-10T14:30:00Z",
+            "endTime": "2024-07-10T15:30:00Z",
+            "object": [{"id": "https://raw.githubusercontent.com/elixir-cloud-aai/CrateGen/main/README.md", "name": "Input 1"}]
+        }
+        model = WRROCProcess(**data)
+        self.assertEqual(model.id, "process-id")
+        self.assertEqual(model.name, "Test Process")
+
+    def test_wrroc_process_empty_object_list(self):
+        """
+        Test that the WRROCProcess model handles empty object lists correctly.
+        """
+        data = {
+            "id": "process-id",
+            "name": "Test Process",
+            "object": []
+        }
+        model = WRROCProcess(**data)
+        self.assertEqual(model.object, [])
+
+    def test_wrroc_workflow_model(self):
+        """
+        Test that the WRROCWorkflow model correctly validates data and includes additional workflow fields.
+        """
+        data = {
+            "id": "workflow-id",
+            "name": "Test Workflow",
+            "workflowType": "CWL",
+            "workflowVersion": "v1.0",
+            "result": [{"id": "https://github.com/elixir-cloud-aai/CrateGen/blob/main/LICENSE", "name": "Output 1"}]
+        }
+        model = WRROCWorkflow(**data)
+        self.assertEqual(model.workflowType, "CWL")
+        self.assertEqual(model.result[0]['name'], "Output 1")
+
+    def test_wrroc_workflow_missing_optional_fields(self):
+        """
+        Test that the WRROCWorkflow model handles missing optional fields correctly.
+        """
+        data = {
+            "id": "workflow-id",
+            "name": "Test Workflow"
+        }
+        model = WRROCWorkflow(**data)
+        self.assertIsNone(model.workflowType)
+        self.assertIsNone(model.workflowVersion)
+
+    def test_wrroc_provenance_model(self):
+        """
+        Test that the WRROCProvenance model correctly validates data and includes additional provenance fields.
+        """
+        data = {
+            "id": "provenance-id",
+            "name": "Test Provenance",
+            "provenanceData": "Provenance information",
+            "agents": [{"id": "agent1", "name": "Agent 1"}]
+        }
+        model = WRROCProvenance(**data)
+        self.assertEqual(model.provenanceData, "Provenance information")
+        self.assertEqual(model.agents[0]['name'], "Agent 1")
+
+    def test_wrroc_provenance_empty_agents_list(self):
+        """
+        Test that the WRROCProvenance model handles empty agents lists correctly.
+        """
+        data = {
+            "id": "provenance-id",
+            "name": "Test Provenance",
+            "agents": []
+        }
+        model = WRROCProvenance(**data)
+        self.assertEqual(model.agents, [])
+
+    def test_wrroc_process_invalid_data(self):
+        """
+        Test that the WRROCProcess model raises a ValidationError with invalid data.
+        """
+        data = {
+            "id": 123,  # id should be a string
+            "name": None  # name should be a string
+        }
+        with self.assertRaises(ValidationError):
+            WRROCProcess(**data)
+
+class TestWRROCValidators(unittest.TestCase):
+    """
+    Unit tests for the WRROC validators to ensure they work as expected.
+    """
+
+    def test_validate_wrroc_process(self):
+        """
+        Test that validate_wrroc correctly identifies a WRROCProcess entity.
+        """
+        data = {
+            "id": "process-id",
+            "name": "Test Process"
+        }
+        model = validate_wrroc(data)
+        self.assertIsInstance(model, WRROCProcess)
+
+    def test_validate_wrroc_workflow(self):
+        """
+        Test that validate_wrroc correctly identifies a WRROCWorkflow entity.
+        """
+        data = {
+            "id": "workflow-id",
+            "name": "Test Workflow",
+            "workflowType": "CWL",
+            "workflowVersion": "v1.0"
+        }
+        model = validate_wrroc(data)
+        self.assertIsInstance(model, WRROCWorkflow)
+
+    def test_validate_wrroc_provenance(self):
+        """
+        Test that validate_wrroc correctly identifies a WRROCProvenance entity.
+        """
+        data = {
+            "id": "provenance-id",
+            "name": "Test Provenance",
+            "provenanceData": "Provenance information"
+        }
+        model = validate_wrroc(data)
+        self.assertIsInstance(model, WRROCProvenance)
+
+    def test_validate_wrroc_invalid(self):
+        """
+        Test that validate_wrroc raises a ValueError for invalid WRROC data.
+        """
+        data = {
+            "unknown_field": "unexpected"
+        }
+        with self.assertRaises(ValueError):
+            validate_wrroc(data)
+
+    def test_validate_wrroc_tes(self):
+        """
+        Test that validate_wrroc_tes correctly validates a WRROC entity for TES conversion.
+        """
+        data = {
+            "id": "process-id",
+            "name": "Test Process",
+            "object": [{"id": "https://raw.githubusercontent.com/elixir-cloud-aai/CrateGen/main/README.md", "name": "Input 1"}],
+            "result": [{"id": "https://github.com/elixir-cloud-aai/CrateGen/blob/main/LICENSE", "name": "Output 1"}]
+        }
+        model = validate_wrroc_tes(data)
+        self.assertEqual(model.id, "process-id")
+        self.assertEqual(model.name, "Test Process")
+
+    def test_validate_wrroc_tes_empty_object_list(self):
+        """
+        Test that validate_wrroc_tes correctly validates a WRROC entity with an empty object list for TES conversion.
+        """
+        data = {
+            "id": "process-id",
+            "name": "Test Process",
+            "object": [],
+            "result": [{"id": "https://github.com/elixir-cloud-aai/CrateGen/blob/main/LICENSE", "name": "Output 1"}]
+        }
+        model = validate_wrroc_tes(data)
+        self.assertEqual(model.object, [])
+
+    def test_validate_wrroc_tes_missing_fields(self):
+        """
+        Test that validate_wrroc_tes raises a ValueError if required fields for TES conversion are missing.
+        """
+        data = {
+            "id": "process-id",
+            "name": "Test Process"
+        }
+        with self.assertRaises(ValueError):
+            validate_wrroc_tes(data)
+
+    def test_validate_wrroc_wes(self):
+        """
+        Test that validate_wrroc_wes correctly validates a WRROC entity for WES conversion.
+        """
+        data = {
+            "id": "workflow-id",
+            "name": "Test Workflow",
+            "workflowType": "CWL",
+            "workflowVersion": "v1.0",
+            "result": [{"id": "https://github.com/elixir-cloud-aai/CrateGen/blob/main/LICENSE", "name": "Output 1"}]
+        }
+        model = validate_wrroc_wes(data)
+        self.assertEqual(model.workflowType, "CWL")
+        self.assertEqual(model.workflowVersion, "v1.0")
+
+    def test_validate_wrroc_wes_invalid_url(self):
+        """
+        Test that validate_wrroc_wes raises a ValueError if a result URL is invalid.
+        """
+        data = {
+            "id": "workflow-id",
+            "name": "Test Workflow",
+            "workflowType": "CWL",
+            "workflowVersion": "v1.0",
+            "result": [{"id": "invalid_url", "name": "Output 1"}]
+        }
+        with self.assertRaises(ValueError):
+            validate_wrroc_wes(data)
+
+
+    def test_validate_wrroc_wes_missing_fields(self):
+        """
+        Test that validate_wrroc_wes raises a ValueError if required fields for WES conversion are missing.
+        """
+        data = {
+            "id": "workflow-id",
+            "name": "Test Workflow"
+        }
+        with self.assertRaises(ValueError):
+            validate_wrroc_wes(data)
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Hi @uniqueg and @SalihuDickson,

## Summary

This PR introduces several key improvements and fixes based on recent feedback:

- **Refactor WRROC Models:**
  - Created a base class `WRROCDataBase` to hold common fields and methods.
  - Refactored `WRROCData`, `WRROCDataTES`, and `WRROCDataWES` to inherit from `WRROCDataBase` to reduce code duplication and enhance maintainability.

- **Stricter Validation:**
  - Replaced `extra = "allow"` with `extra = "forbid"` in all WRROC models (`WRROCProcess`, `WRROCWorkflow`, `WRROCProvenance`) to enforce stricter validation.

- **Enhanced Validation and Error Collection:**
  - Modified validation functions to collect and report all errors found during validation, ensuring comprehensive feedback.
  - Simplified field validation by removing manual checks for extra fields and leveraging Pydantic's `extra = "forbid"` configuration.

- **Expanded Unit Tests:**
  - Added test cases for edge scenarios such as empty object or result lists, missing optional fields, and incorrect data types.
  - Implemented tests for invalid URLs and other edge cases.
  - Fixed existing tests by allowing empty lists and adding URL validation in the WES conversion validation.
